### PR TITLE
Added fallible (`*_try_do()`) methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 name = "bool_ext"
 readme = "README.md"
 repository = "https://github.com/u007d/bool_ext"
-version = "0.4.1"
+version = "0.4.2"
 
 [dependencies]
 


### PR DESCRIPTION
* Add and|or_try_do() methods to perform fallible side-effects on boolean values.
* Fix unsynchronized documentation issue in v0.4.1.